### PR TITLE
(Suggestion) Simple fix for image spacing\

### DIFF
--- a/_posts/2018-05-19-week1.md
+++ b/_posts/2018-05-19-week1.md
@@ -8,15 +8,19 @@ Most of this week was dedicated to final exams and learning the codebase for the
 Packaging was a goal for this week, but there have been issues with making binary distributions of the server facade with jenkins, so this goal is put on hold for a short amount of time. I have played around a bit with the launcher, and I think I have a good idea of what to do to make the FacadeServer easy to download.
 Now that the first week is over and I have more knowledge of what I am working with, I should be able work much quicker.
 Code this week consists of two main things worked on.
-[Code for the logout button](https://github.com/MovingBlocks/FacadeServer-frontend/pull/2){:.gh-pr}
-![LogoutButton]({{ site.baseurl }}/images/LogoutButton.PNG)
+[Code for the logout button](https://github.com/MovingBlocks/FacadeServer-frontend/pull/2){:.gh-pr}\\
+\\
+![LogoutButton]({{ site.baseurl }}/images/LogoutButton.PNG)\\
+\\
 I added a logout button to the frontend. This button currently just refreshes the page, which both logs the user out and also disconnects them from the server. Ideally, it should only log the user out.
-Also, the native build for Android (and iOS too) appears to not work correctly. There is no logout button for it at the moment.
-![CpuAndMemoryUsagePercentage]({{ site.baseurl }}/images/CPUMemoryPercentage.PNG)
+Also, the native build for Android (and iOS too) appears to not work correctly. There is no logout button for it at the moment.\\
+\\
+![CpuAndMemoryUsagePercentage]({{ site.baseurl }}/images/CPUMemoryPercentage.PNG)\\
+\\
 It appears that the memory percentage reported is slightly lower with SIGAR than with task manager, but it is a minimal difference. Maybe the difference is caused by the server being on a local machine. Code for this isn't yet in any PR, but there should be one on Sunday or Monday.
 SIGAR makes it really easy to get a lot of data about the system. This is all you need for the CPU usage:
 ```Java
-Sigar sigar = new Sigar();
+	Sigar sigar = new Sigar();
         try {
             CpuPerc cpuperc = sigar.getCpuPerc();
         } catch (SigarException e) {


### PR DESCRIPTION
Hello there,
since you are using the same website template I used last year and I remember I had the same problem your site is experiencing with images not aligning correctly, here I'm suggesting a fix.

Basically, quoting [kramdown documentation](https://kramdown.gettalong.org/quickref.html),
> Explicit line breaks in a paragraph can be made by using two spaces or two backslashes at the end of a line

In the attachments you can see the before/after screenshots.
I also fixed the indentation in the code block.

Also in case you are interested in running the site locally (I did it to test this change), you may have a look at installing [Jekyll](https://jekyllrb.com/). However on Windows is quite a pain if I remember correctly.

![before](https://user-images.githubusercontent.com/15270303/40282700-7c997ac4-5c73-11e8-96c4-7bf2d25fc13c.png)
![after](https://user-images.githubusercontent.com/15270303/40282699-7c494090-5c73-11e8-8187-5e57edc98c71.png)